### PR TITLE
Atualiza home para usar API do Render

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import { styles } from "./styles";
 
 type HeaderProps = {
@@ -6,22 +6,52 @@ type HeaderProps = {
   deliveryAddress?: string;
 };
 
-export function Header({ userName = "Olá", deliveryAddress = "Rua São Geraldo, 245" }: HeaderProps) {
+function getInitials(name: string) {
+  const parts = name
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return "CL";
+  }
+
+  if (parts.length === 1) {
+    const [first] = parts;
+    return first.slice(0, 2).toUpperCase();
+  }
+
+  const firstInitial = parts[0][0];
+  const lastInitial = parts[parts.length - 1][0];
+  return `${firstInitial}${lastInitial}`.toUpperCase();
+}
+
+function getFirstName(name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "Cliente";
+  }
+
+  const [first] = trimmed.split(/\s+/);
+  return first;
+}
+
+export function Header({ userName = "Maria Souza", deliveryAddress = "Rua São Geraldo, 245" }: HeaderProps) {
+  const initials = getInitials(userName);
+  const firstName = getFirstName(userName);
+
   return (
     <View style={styles.container}>
       <View style={styles.textContainer}>
-        <Text style={styles.greeting}>{userName}</Text>
+        <Text style={styles.greeting}>Olá, {firstName}</Text>
         <View style={styles.addressRow}>
           <Text style={styles.addressLabel}>Entregando em</Text>
           <Text style={styles.addressValue}>{deliveryAddress}</Text>
         </View>
       </View>
-      <Image
-        source={{
-          uri: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=160&q=60",
-        }}
-        style={styles.avatar}
-      />
+      <View style={styles.avatar}>
+        <Text style={styles.avatarText}>{initials}</Text>
+      </View>
     </View>
   );
 }

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -37,5 +37,13 @@ export const styles = StyleSheet.create({
     width: 46,
     height: 46,
     borderRadius: radius.pill,
+    backgroundColor: colors.primary,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarText: {
+    color: colors.cardBackground,
+    fontSize: typography.subtitle,
+    fontWeight: "700",
   },
 });

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -17,14 +17,13 @@ export function ProductCard({ product, onPress }: ProductCardProps) {
         </View>
       ) : null}
 
-      <Image
-        style={styles.image}
-        source={{
-          uri:
-            product.imageUrl ??
-            "https://images.unsplash.com/photo-1511690656952-34342bb7c2f2?auto=format&fit=crop&w=800&q=60",
-        }}
-      />
+      {product.imageUrl ? (
+        <Image style={styles.image} source={{ uri: product.imageUrl }} />
+      ) : (
+        <View style={styles.placeholder}>
+          <Text style={styles.placeholderText}>{product.name.slice(0, 2).toUpperCase()}</Text>
+        </View>
+      )}
 
       <View style={styles.info}>
         <Text style={styles.name} numberOfLines={2}>

--- a/src/components/ProductCard/styles.ts
+++ b/src/components/ProductCard/styles.ts
@@ -31,6 +31,21 @@ export const styles = StyleSheet.create({
     borderRadius: radius.md,
     marginBottom: spacing.md,
   },
+  placeholder: {
+    width: "100%",
+    height: 120,
+    borderRadius: radius.md,
+    marginBottom: spacing.md,
+    backgroundColor: colors.border,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  placeholderText: {
+    fontSize: typography.subtitle,
+    fontWeight: "700",
+    color: colors.mutedText,
+    textTransform: "uppercase",
+  },
   info: {
     gap: spacing.xs,
   },

--- a/src/hooks/useMarketData.ts
+++ b/src/hooks/useMarketData.ts
@@ -1,17 +1,8 @@
 import { useEffect, useState } from "react";
-import {
-  Category,
-  Product,
-  Promotion,
-  fetchCategories,
-  fetchDailyEssentials,
-  fetchFeaturedProducts,
-  fetchPromotions,
-} from "../services/api";
+import { Category, Product, fetchCategories, fetchDailyEssentials, fetchFeaturedProducts } from "../services/api";
 
 type MarketData = {
   categories: Category[];
-  promotions: Promotion[];
   featured: Product[];
   essentials: Product[];
   isLoading: boolean;
@@ -21,7 +12,6 @@ type MarketData = {
 export function useMarketData() {
   const [data, setData] = useState<MarketData>({
     categories: [],
-    promotions: [],
     featured: [],
     essentials: [],
     isLoading: true,
@@ -33,9 +23,8 @@ export function useMarketData() {
 
     async function load() {
       try {
-        const [categories, promotions, featured, essentials] = await Promise.all([
+        const [categories, featured, essentials] = await Promise.all([
           fetchCategories(),
-          fetchPromotions(),
           fetchFeaturedProducts(),
           fetchDailyEssentials(),
         ]);
@@ -44,7 +33,6 @@ export function useMarketData() {
 
         setData({
           categories,
-          promotions,
           featured,
           essentials,
           isLoading: false,

--- a/src/screens/Home/HomeScreen.tsx
+++ b/src/screens/Home/HomeScreen.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, ScrollView, Text, View } from "react-native";
-import { BannerCard } from "../../components/BannerCard/BannerCard";
 import { CategoryPill } from "../../components/CategoryPill/CategoryPill";
 import { Header } from "../../components/Header/Header";
 import { InfoRow } from "../../components/InfoRow/InfoRow";
@@ -15,7 +14,7 @@ import { styles } from "./styles";
 export function HomeScreen() {
   const [search, setSearch] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const { categories, promotions, featured, essentials, isLoading, hasError } = useMarketData();
+  const { categories, featured, essentials, isLoading, hasError } = useMarketData();
 
   const filteredEssentials = useMemo(() => {
     const query = search.toLowerCase();
@@ -32,7 +31,7 @@ export function HomeScreen() {
 
   return (
     <ScrollView style={styles.screen} showsVerticalScrollIndicator={false}>
-      <Header userName="Olá, Maria" />
+      <Header userName="Maria Souza" />
 
       <View style={styles.searchContainer}>
         <SearchBar value={search} onChangeText={setSearch} />
@@ -56,10 +55,6 @@ export function HomeScreen() {
           )}
         />
       </View>
-
-      {promotions.map((promotion) => (
-        <BannerCard key={promotion.id} promotion={promotion} />
-      ))}
 
       <View style={styles.sectionSpacing}>
         <SectionTitle title="Ofertas especiais" actionLabel="Ver mais" />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -22,7 +22,7 @@ export type Product = {
   promotionBadge?: string | null;
 };
 
-const DEFAULT_API_URL = "https://mercadinho-sao-geraldo-api.fly.dev";
+const DEFAULT_API_URL = "https://mercadinho-sao-geraldo-api.onrender.com";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? DEFAULT_API_URL;
 
@@ -50,89 +50,17 @@ async function fetchFromApi<T>(endpoint: string, options?: FetchOptions): Promis
 }
 
 export async function fetchCategories(): Promise<Category[]> {
-  try {
-    const data = await fetchFromApi<Category[]>("/categories");
-    return data;
-  } catch {
-    return [
-      { id: "fresh", name: "Hortifruti", iconUrl: "https://cdn-icons-png.flaticon.com/512/766/766741.png" },
-      { id: "butcher", name: "Açougue", iconUrl: "https://cdn-icons-png.flaticon.com/512/1046/1046780.png" },
-      { id: "bakery", name: "Padaria", iconUrl: "https://cdn-icons-png.flaticon.com/512/1046/1046751.png" },
-      { id: "cleaning", name: "Limpeza", iconUrl: "https://cdn-icons-png.flaticon.com/512/1046/1046766.png" },
-    ];
-  }
+  return fetchFromApi<Category[]>("/categories");
 }
 
 export async function fetchPromotions(): Promise<Promotion[]> {
-  try {
-    const data = await fetchFromApi<Promotion[]>("/promotions");
-    return data;
-  } catch {
-    return [
-      {
-        id: "welcome",
-        title: "Bem-vindo ao Mercadinho São Geraldo",
-        description: "Entrega rápida para toda a região do bairro!",
-        bannerImageUrl:
-          "https://images.unsplash.com/photo-1581550250634-6c2ff0b8d095?auto=format&fit=crop&w=1200&q=60",
-      },
-    ];
-  }
+  return fetchFromApi<Promotion[]>("/promotions");
 }
 
 export async function fetchFeaturedProducts(): Promise<Product[]> {
-  try {
-    const data = await fetchFromApi<Product[]>("/products/featured");
-    return data;
-  } catch {
-    return [
-      {
-        id: "banana",
-        name: "Banana Nanica",
-        price: 5.5,
-        unit: "kg",
-        promotionBadge: "Oferta",
-        imageUrl: "https://images.unsplash.com/photo-1574226516831-e1dff420e43e?auto=format&fit=crop&w=800&q=60",
-      },
-      {
-        id: "picanha",
-        name: "Picanha Bovina",
-        price: 79.9,
-        unit: "kg",
-        promotionBadge: "Fresquinho",
-        imageUrl: "https://images.unsplash.com/photo-1604908177532-4023ac76d396?auto=format&fit=crop&w=800&q=60",
-      },
-    ];
-  }
+  return fetchFromApi<Product[]>("/products/featured");
 }
 
 export async function fetchDailyEssentials(): Promise<Product[]> {
-  try {
-    const data = await fetchFromApi<Product[]>("/products/essentials");
-    return data;
-  } catch {
-    return [
-      {
-        id: "pao-frances",
-        name: "Pão Francês",
-        price: 12.9,
-        unit: "kg",
-        imageUrl: "https://images.unsplash.com/photo-1514996937319-344454492b37?auto=format&fit=crop&w=800&q=60",
-      },
-      {
-        id: "detergente",
-        name: "Detergente Limão",
-        price: 2.99,
-        unit: "unidade",
-        imageUrl: "https://images.unsplash.com/photo-1581578731548-c64695cc6952?auto=format&fit=crop&w=800&q=60",
-      },
-      {
-        id: "cafe",
-        name: "Café Torrado",
-        price: 18.9,
-        unit: "500g",
-        imageUrl: "https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=60",
-      },
-    ];
-  }
+  return fetchFromApi<Product[]>("/products/essentials");
 }


### PR DESCRIPTION
## Summary
- atualiza o serviço de API para usar a instância hospedada no Render e remove dados mockados
- ajusta o cabeçalho para exibir as iniciais do usuário em vez de imagem e remove banners promocionais
- garante que os cards de produto tratem a ausência de imagens com um placeholder textual

## Testing
- não executado (ambiente sem Expo)


------
https://chatgpt.com/codex/tasks/task_e_68d7f4669128833084d1b7d914b69359